### PR TITLE
Update spec.json

### DIFF
--- a/ui/narrative/methods/create_taxonomy/spec.json
+++ b/ui/narrative/methods/create_taxonomy/spec.json
@@ -16,7 +16,9 @@
             "advanced": false,
             "allow_multiple": false,
             "default_values": [ "Klebsiella sp. janaka" ],
-            "field_type": "text",
+            "field_type": "autocorrect",
+            "service" : "taxonomy_service",
+            "requires_selection" : true,
             "text_options": {
                 "validate_as": "text"
             }


### PR DESCRIPTION
scientific_name becomes an autocomplete field_type, which should be all we need in this case.
Added the service and requires_selection params for completeness' sake.